### PR TITLE
Use selenium defaults along with explicit capabiltities in Firefox webdriver

### DIFF
--- a/capybara/selenium/driver.py
+++ b/capybara/selenium/driver.py
@@ -6,6 +6,7 @@ from selenium.common.exceptions import (
     NoSuchWindowException,
     StaleElementReferenceException,
     UnexpectedAlertPresentException)
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 from time import sleep, time
@@ -24,9 +25,10 @@ class Driver(Base):
 
     @cached_property
     def browser(self):
-        browser = webdriver.Firefox(
-            # Auto-accept unload alerts triggered by navigating away.
-            capabilities={"unexpectedAlertBehaviour": "ignore"})
+        capabilities = DesiredCapabilities.FIREFOX.copy()
+        # Auto-accept unload alerts triggered by navigating away.
+        capabilities["unexpectedAlertBehaviour"] = "ignore"
+        browser = webdriver.Firefox(capabilities=capabilities)
         atexit.register(browser.quit)
         return browser
 


### PR DESCRIPTION
With the latest capybara.py I was unable to get anything working because the latest builds of Firefox (since 47) want to use the new geckodriver that requires the capability `'marionette': True`, which capybara doesn't provide to the `webdriver.Firefox` call.

Using the default capabilities dictionary available in selenium and adding to that solves this issue since `'marionette': True` has become a default in selenium, and using the default dictionary is probably a better idea in general anyway.