### PR TITLE
allow passing selenium drivers driver-specific extra configuration

### DIFF
--- a/capybara/selenium/browser.py
+++ b/capybara/selenium/browser.py
@@ -2,24 +2,25 @@ from selenium import webdriver
 from selenium.webdriver import DesiredCapabilities
 
 
-def get_browser(browser_name, capabilities=None):
+def get_browser(browser_name, capabilities=None, config_obj=None):
     """
-    Returns an instance of the given browser with the given capabilities.
+    Returns an instance of the given browser with the given capabilities and options.
 
     Args:
         browser_name (str): The name of the desired browser.
         capabilities (Dict[str, str | bool], optional): The desired capabilities of the browser. Defaults to None.
+        config_obj (object, optional): An additional configuration object instance appropriate for the requested browser. (ChromeOptions, FirefoxProfile)
 
     Returns:
         WebDriver: An instance of the desired browser.
     """
 
     if browser_name == "chrome":
-        return webdriver.Chrome(desired_capabilities=capabilities)
+        return webdriver.Chrome(desired_capabilities=capabilities, chrome_options=config_obj)
     if browser_name == "edge":
         return webdriver.Edge(capabilities=capabilities)
     if browser_name in ["ff", "firefox"]:
-        return webdriver.Firefox(capabilities=capabilities)
+        return webdriver.Firefox(capabilities=capabilities, firefox_profile=config_obj)
     if browser_name in ["ie", "internet_explorer"]:
         return webdriver.Ie(capabilities=capabilities)
     if browser_name == "phantomjs":

--- a/capybara/selenium/driver.py
+++ b/capybara/selenium/driver.py
@@ -5,6 +5,7 @@ from selenium.common.exceptions import (
     NoSuchWindowException,
     StaleElementReferenceException,
     UnexpectedAlertPresentException)
+from selenium.webdriver import ChromeOptions
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support import expected_conditions as EC
@@ -29,12 +30,15 @@ class Driver(Base):
         desired_capabilities (Dict[str, str | bool], optional): Desired
             capabilities of the underlying browser. Defaults to a set of
             reasonable defaults provided by Selenium.
+        config_obj (object, optional): An additional configuration object instance appropriate for the requested browser. (ChromeOptions, FirefoxProfile)
     """
 
-    def __init__(self, app, browser="firefox", desired_capabilities=None):
+    def __init__(self, app, browser="firefox", desired_capabilities=None,
+                 config_obj=None):
         self.app = app
         self._browser_name = browser
         self._desired_capabilities = desired_capabilities
+        self._config_obj = config_obj
         self._frame_handles = []
 
     @property
@@ -49,8 +53,11 @@ class Driver(Base):
             capabilities = (capabilities or DesiredCapabilities.FIREFOX).copy()
             # Auto-accept unload alerts triggered by navigating away.
             capabilities["unexpectedAlertBehaviour"] = "ignore"
+        elif self._browser_name == "chrome":
+            capabilities = (capabilities or DesiredCapabilities.CHROME).copy()
 
-        browser = get_browser(self._browser_name, capabilities=capabilities)
+        browser = get_browser(self._browser_name, capabilities=capabilities,
+                              config_obj=self._config_obj)
         atexit.register(browser.quit)
         return browser
 


### PR DESCRIPTION
It'd be convenient for my use cases to be able to append extra arguments to Chrome or other selenium driver instances that selenium supports through the `chrome_options` or other driver-specific arguments, and quite possibly other people have the same desires.