### PR TITLE
Fix bug with DSLMixin

### DIFF
--- a/capybara/dsl.py
+++ b/capybara/dsl.py
@@ -37,11 +37,15 @@ def _define_package_method(name):
 
 def _define_session_method(name):
     @wraps(getattr(Session, name))
-    def func(*args, **kwargs):
+    def class_func(self, *args, **kwargs):
         return getattr(page, name)(*args, **kwargs)
 
-    setattr(DSLMixin, name, func)
-    setattr(_module, name, func)
+    @wraps(getattr(Session, name))
+    def module_func(*args, **kwargs):
+        return getattr(page, name)(*args, **kwargs)
+
+    setattr(DSLMixin, name, class_func)
+    setattr(_module, name, module_func)
 
 
 for _method in PACKAGE_METHODS:

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -139,3 +139,15 @@ class TestUsingSession(DSLTestCase):
 class TestSessionName(DSLTestCase):
     def test_defaults_to_default(self):
         assert capybara.session_name == "default"
+
+
+class TestUsingDSLMixin(DSLTestCase):
+    @pytest.fixture
+    def myclass(self):
+        from capybara.dsl import DSLMixin
+        class MyClass(DSLMixin):
+            pass
+        return MyClass()
+
+    def test_uses_current_session(self, myclass):
+        assert myclass.has_no_current_path("/")


### PR DESCRIPTION
Creating a class that inherits from DSLMixin should allow it to use DSL methods, however instead I get a KeyError

## Steps to reproduce bug

1. Create a class that inherits from DSLMixin
2. Instantiate the class
3. Call a DSL method

```
>>> from capybara.dsl import DSLMixin

>>> class MyClass(DSLMixin):
...     pass
>>> mypage = MyClass()
>>> mypage.assert_selector('link', 'Help')
```

## Expected behaviour

The DSL method returns as if calling `capybara.dsl.<method>`

```
>>> mypage.assert_selector('link', 'Help')
True
```

## Actual behaviour

A KeyError is raised

```
>>> mypage.assert_selector('link', 'Help')
*** KeyError: <MyClass object at 0x7f16a350d780>
```

## Suggested fix

DSLMixin should result in methods being attached to the class, rather than functions, so that the DSL methods can be used from instances of classes that inherit from DSLMixin.

I've attached a fix below that includes tests showing the behaviour I would expect.