### PR TITLE
Support pytest >= 4

### DIFF
--- a/capybara/pytest_plugin.py
+++ b/capybara/pytest_plugin.py
@@ -5,10 +5,10 @@ import capybara.dsl
 
 
 def pytest_runtest_setup(item):
-    if item.get_marker("js"):
+    if item.get_closest_marker("js"):
         capybara.current_driver = capybara.javascript_driver
 
-    driver = item.get_marker("driver")
+    driver = item.get_closest_marker("driver")
     if driver:
         assert len(driver.args) == 1, "exactly one driver must be specified"
         capybara.current_driver = driver.args[0]

--- a/capybara/tests/pytest_plugin.py
+++ b/capybara/tests/pytest_plugin.py
@@ -17,7 +17,7 @@ def pytest_pycollect_makeitem(collector, name, obj):
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_setup(item):
     # See if this test ``requires`` any special driver features.
-    requires = item.get_marker("requires")
+    requires = item.get_closest_marker("requires")
     if requires is not None:
         driver = item.getparent(Driver).obj
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ driver_verification_tests_require = [
     "flaky",
     "flask",
     "py",
-    "pytest ~= 3.0, != 3.3.*, < 3.7",
+    "pytest >= 4.0",
     "werkzeug"]
 if sys.version_info < (3, 3):
     driver_verification_tests_require.append("mock")


### PR DESCRIPTION
Currently capybara only supports pytest 3 because of the deprecated get_marker.
This fixes that and supports modern pytest versions