### PR TITLE
Workaround to remove / fix deprecation warning

### DIFF
--- a/capybara/compat.py
+++ b/capybara/compat.py
@@ -21,3 +21,9 @@ else:
 
     def cmp(a, b):
         return (a > b) - (a < b)
+
+try:
+    from collections.abc import Hashable
+except ImportError:
+    # deprecated since python 3.3
+    from collections import Hashable

--- a/capybara/node/matchers.py
+++ b/capybara/node/matchers.py
@@ -1,7 +1,7 @@
-from collections import Hashable
 from functools import wraps
 
 import capybara
+from capybara.compat import Hashable
 from capybara.exceptions import ExpectationNotMet
 from capybara.helpers import expects_none, matches_count
 from capybara.selector import selectors

--- a/capybara/queries/selector_query.py
+++ b/capybara/queries/selector_query.py
@@ -1,11 +1,10 @@
-from collections import Hashable
 from functools import reduce
 import re
 from xpath.expression import AbstractExpression
 from xpath.renderer import to_xpath
 
 import capybara
-from capybara.compat import bytes_, str_
+from capybara.compat import Hashable, bytes_, str_
 from capybara.helpers import desc, normalize_text, toregex
 from capybara.queries.base_query import BaseQuery
 from capybara.result import Result

--- a/capybara/session.py
+++ b/capybara/session.py
@@ -1,4 +1,3 @@
-from collections import Hashable
 from contextlib import contextmanager
 from datetime import datetime
 from functools import wraps
@@ -6,7 +5,7 @@ import os
 import random
 
 import capybara
-from capybara.compat import ParseResult, urlparse
+from capybara.compat import Hashable, ParseResult, urlparse
 from capybara.driver.node import Node
 from capybara.exceptions import ScopeError, WindowError
 from capybara.node.base import Base


### PR DESCRIPTION
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working

Hope you like it, any comments on how you want this kind of change?